### PR TITLE
add a link to the oSTEM code of conduct

### DIFF
--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -43,7 +43,7 @@ We are dedicated to the relentless pursuit of our vision.
 We push forward with courage and determination, regardless of the circumstances,
 to achieve our mission.
 
-Visit our oSTEM Code of Conduct
+Visit our [oSTEM Code of Conduct](https://drive.google.com/file/d/1dFcnUKUsUFAJ9_zUhrLGxioGwo8JK1wL/view)
 
 ## Commitment to Diversity & Inclusion
 


### PR DESCRIPTION
I noticed there was a link missing on this page to the code of conduct. 